### PR TITLE
Add upcoming territory expiry section

### DIFF
--- a/src/components/ExpiryCard.tsx
+++ b/src/components/ExpiryCard.tsx
@@ -1,0 +1,15 @@
+import type { Territory } from "../types";
+
+interface Props {
+  territorio: Pick<Territory, "numero" | "fecha_devolucion" | "usuario_asignado">;
+}
+
+export default function ExpiryCard({ territorio }: Props) {
+  return (
+    <div className="bg-white rounded-lg shadow p-4 border border-gray-200">
+      <h3 className="text-lg font-semibold mb-1">Territorio #{territorio.numero}</h3>
+      <p className="text-sm text-gray-500">Vence: {territorio.fecha_devolucion?.slice(0, 10) || "-"}</p>
+      <p className="text-sm">Responsable: {territorio.usuario_asignado?.nombre || "Ninguno"}</p>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,14 +1,20 @@
 // src/pages/Dashboard.tsx
 import { useEffect, useState } from "react";
-import { getTerritorios } from "../services/territories";
+import { getTerritorios, getTerritoriosProximosVencer } from "../services/territories";
+import ExpiryCard from "../components/ExpiryCard";
 import type { Territory } from "../types/territory";
 
 export default function Dashboard() {
   const [territorios, setTerritorios] = useState<Territory[]>([]);
+  const [vencimientos, setVencimientos] = useState<Territory[]>([]);
 
   useEffect(() => {
     getTerritorios()
       .then(setTerritorios)
+      .catch(console.error);
+
+    getTerritoriosProximosVencer()
+      .then(setVencimientos)
       .catch(console.error);
   }, []);
 
@@ -49,17 +55,27 @@ export default function Dashboard() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             }
           />
-          <SummaryCard
-            color="red"
-            label="Inhabilitados"
-            value={inhabilitados}
-            icon={
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01" />
-            }
-          />
-        </div>
+        <SummaryCard
+          color="red"
+          label="Inhabilitados"
+          value={inhabilitados}
+          icon={
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01" />
+          }
+        />
+      </div>
 
-        {/* TODO: Gráficos, Vencimientos, Cards... */}
+        {vencimientos.length > 0 && (
+          <div className="mt-8">
+            <h3 className="text-lg font-semibold text-gray-800 mb-4">Próximos vencimientos</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {vencimientos.map((t) => (
+                <ExpiryCard key={t.id} territorio={t} />
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Puedes seguir extendiendo aquí */}
       </main>
     </div>

--- a/src/services/territories.ts
+++ b/src/services/territories.ts
@@ -39,3 +39,18 @@ export async function deleteTerritorio(id: string) {
   const { error } = await supabase.from("territorios").delete().eq("id", id);
   if (error) throw new Error(error.message);
 }
+
+export async function getTerritoriosProximosVencer(limit = 5) {
+  const { data, error } = await supabase
+    .from("territorios")
+    .select(
+      "id, numero, estado, fecha_devolucion, usuario_asignado(id, nombre)"
+    )
+    .eq("estado", "en_uso")
+    .gt("fecha_devolucion", new Date().toISOString())
+    .order("fecha_devolucion", { ascending: true })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+  return data as Territory[];
+}

--- a/src/types/territory.ts
+++ b/src/types/territory.ts
@@ -6,4 +6,5 @@ export interface Territory {
   numero: number;
   estado: string;
   usuario_asignado: User | null;
+  fecha_devolucion?: string | null;
 }


### PR DESCRIPTION
## Summary
- add `fecha_devolucion` optional field in Territory type
- create `getTerritoriosProximosVencer` service API
- show upcoming expirations in `Dashboard`
- add `ExpiryCard` component to display each territory

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cad662f208329b10a972252e7d224