### PR TITLE
Add status badge for territory state

### DIFF
--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,0 +1,27 @@
+import clsx from "clsx";
+
+type Props = {
+  estado: string;
+};
+
+const colorMap: Record<string, string> = {
+  disponible: "bg-green-100 text-green-800",
+  en_uso: "bg-yellow-100 text-yellow-800",
+  inhabilitado: "bg-gray-200 text-gray-800",
+  caducado: "bg-red-100 text-red-800",
+  especial: "bg-purple-100 text-purple-800",
+};
+
+export default function StatusBadge({ estado }: Props) {
+  const classes = colorMap[estado] || "bg-gray-100 text-gray-800";
+  return (
+    <span
+      className={clsx(
+        "px-2 py-0.5 rounded-full text-xs font-medium capitalize",
+        classes
+      )}
+    >
+      {estado.replace("_", " ")}
+    </span>
+  );
+}

--- a/src/components/TerritoryCard.tsx
+++ b/src/components/TerritoryCard.tsx
@@ -1,3 +1,5 @@
+import StatusBadge from "./StatusBadge";
+
 interface Props {
   territorio: {
     numero: number;
@@ -10,9 +12,10 @@ export default function TerritoryCard({ territorio }: Props) {
   return (
     <div className="bg-white rounded-2xl shadow p-4 border border-gray-200">
       <h2 className="text-lg font-semibold">Territorio #{territorio.numero}</h2>
-      <p className="text-sm text-gray-500 capitalize">
-        Estado: {territorio.estado.replace("_", " ")}
-      </p>
+      <div className="text-sm text-gray-500 flex items-center space-x-1">
+        <span>Estado:</span>
+        <StatusBadge estado={territorio.estado} />
+      </div>
       <p className="text-sm">
         Responsable: {territorio.usuario_asignado?.nombre || "Ninguno"}
       </p>


### PR DESCRIPTION
## Summary
- add `StatusBadge` component for colored state pills
- use `StatusBadge` in `TerritoryCard` to show each territory's state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684caf4f266c8329a4aef4250e83e1ea